### PR TITLE
feat: 新增發文、留言、心情

### DIFF
--- a/POST_SYSTEM_API.md
+++ b/POST_SYSTEM_API.md
@@ -1,0 +1,419 @@
+# 發文、留言、心情系統 API 文檔
+
+## 📝 文章 API
+
+### 1. 建立文章
+**POST** `/posts`
+
+**需要登入**: ✅
+
+**Request Body**:
+```json
+{
+  "title": "我的第一篇文章",
+  "content": "這是文章的完整內容...",
+  "summary": "這是文章摘要",
+  "cover_image": "https://example.com/image.jpg",
+  "status": "published",
+  "visibility": "public",
+  "tags": ["技術", "Go語言", "教學"]
+}
+```
+
+**欄位說明**:
+- `title` (string, required): 文章標題，1-255 字元
+- `content` (string, required): 文章內容
+- `summary` (string, optional): 文章摘要，最多 500 字元
+- `cover_image` (string, optional): 封面圖片 URL
+- `status` (string, optional): 狀態，可選 `draft`、`published`、`archived`，預設 `draft`
+- `visibility` (string, optional): 可見性，可選 `public`、`private`、`friends`，預設 `public`
+- `tags` (array, optional): 標籤陣列
+
+**Response (201)**:
+```json
+{
+  "message": "Post created successfully",
+  "post": {
+    "ID": 1,
+    "CreatedAt": "2025-11-07T10:00:00Z",
+    "UpdatedAt": "2025-11-07T10:00:00Z",
+    "title": "我的第一篇文章",
+    "content": "這是文章的完整內容...",
+    "status": "published",
+    "visibility": "public",
+    "view_count": 0,
+    "author": {
+      "ID": 1,
+      "nickname": "user123"
+    },
+    "tags": [
+      {"ID": 1, "name": "技術", "color": "#3B82F6"},
+      {"ID": 2, "name": "Go語言", "color": "#3B82F6"}
+    ]
+  }
+}
+```
+
+---
+
+### 2. 取得文章列表
+**GET** `/posts`
+
+**需要登入**: ❌（選擇性）
+
+**Query Parameters**:
+- `page` (int, optional): 頁碼，預設 1
+- `page_size` (int, optional): 每頁數量，預設 10，最多 100
+- `status` (string, optional): 篩選狀態
+- `tag` (string, optional): 篩選標籤
+
+**範例**: `/posts?page=1&page_size=10&tag=技術`
+
+**Response (200)**:
+```json
+{
+  "posts": [
+    {
+      "ID": 1,
+      "title": "我的第一篇文章",
+      "summary": "這是文章摘要",
+      "author": {
+        "ID": 1,
+        "nickname": "user123"
+      },
+      "tags": [...],
+      "view_count": 42,
+      "created_at": "2025-11-07T10:00:00Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 10,
+    "total": 25,
+    "total_pages": 3
+  }
+}
+```
+
+---
+
+### 3. 取得單一文章
+**GET** `/posts/:id`
+
+**需要登入**: ❌（選擇性，私人文章需要）
+
+**Response (200)**:
+```json
+{
+  "post": {
+    "ID": 1,
+    "title": "我的第一篇文章",
+    "content": "完整內容...",
+    "author": {...},
+    "tags": [...],
+    "comments": [...],
+    "reactions": [...],
+    "view_count": 43
+  }
+}
+```
+
+---
+
+### 4. 更新文章
+**PUT** `/posts/:id`
+
+**需要登入**: ✅（僅作者）
+
+**Request Body**: 與建立文章相同，所有欄位都是選擇性的
+
+---
+
+### 5. 刪除文章
+**DELETE** `/posts/:id`
+
+**需要登入**: ✅（僅作者或管理員）
+
+**Response (200)**:
+```json
+{
+  "message": "Post deleted successfully"
+}
+```
+
+---
+
+## 💬 留言 API
+
+### 1. 建立留言
+**POST** `/posts/:id/comments`
+
+**需要登入**: ✅
+
+**Request Body**:
+```json
+{
+  "content": "這是我的留言內容",
+  "parent_id": null
+}
+```
+
+**欄位說明**:
+- `content` (string, required): 留言內容
+- `parent_id` (uint, optional): 父留言 ID（用於回覆）
+
+**Response (201)**:
+```json
+{
+  "message": "Comment created successfully",
+  "comment": {
+    "ID": 1,
+    "post_id": 1,
+    "content": "這是我的留言內容",
+    "author": {
+      "ID": 1,
+      "nickname": "user123"
+    },
+    "parent_id": null,
+    "created_at": "2025-11-07T10:00:00Z"
+  }
+}
+```
+
+---
+
+### 2. 取得文章的所有留言
+**GET** `/posts/:id/comments`
+
+**需要登入**: ❌
+
+**Response (200)**:
+```json
+{
+  "comments": [
+    {
+      "ID": 1,
+      "content": "這是留言",
+      "author": {...},
+      "replies": [
+        {
+          "ID": 2,
+          "content": "這是回覆",
+          "author": {...},
+          "parent_id": 1
+        }
+      ],
+      "reactions": [...],
+      "is_edited": false
+    }
+  ]
+}
+```
+
+---
+
+### 3. 更新留言
+**PUT** `/comments/:comment_id`
+
+**需要登入**: ✅（僅作者）
+
+**Request Body**:
+```json
+{
+  "content": "更新後的留言內容"
+}
+```
+
+---
+
+### 4. 刪除留言（軟刪除）
+**DELETE** `/comments/:comment_id`
+
+**需要登入**: ✅（僅作者或管理員）
+
+**說明**: 留言會被標記為已刪除，內容改為 "[此留言已刪除]"，但結構保留（為了維持對話串的完整性）
+
+---
+
+## ❤️ 反應/心情 API
+
+### 1. 對文章新增反應
+**POST** `/posts/:id/reactions`
+
+**需要登入**: ✅
+
+**Request Body**:
+```json
+{
+  "type": "like"
+}
+```
+
+**反應類型**:
+- `like` - 讚 👍
+- `love` - 愛心 ❤️
+- `haha` - 哈哈 😆
+- `wow` - 驚訝 😮
+- `sad` - 難過 😢
+- `angry` - 生氣 😠
+- `care` - 關心 🤗
+
+**行為說明**:
+- 第一次：新增反應
+- 相同類型：取消反應
+- 不同類型：更新反應
+
+**Response (201/200)**:
+```json
+{
+  "message": "Reaction added",
+  "reaction": {
+    "ID": 1,
+    "user_id": 1,
+    "post_id": 1,
+    "type": "like"
+  }
+}
+```
+
+---
+
+### 2. 對留言新增反應
+**POST** `/comments/:comment_id/reactions`
+
+**需要登入**: ✅
+
+**Request Body**: 與文章反應相同
+
+---
+
+### 3. 取得文章的反應統計
+**GET** `/posts/:id/reactions`
+
+**需要登入**: ❌（選擇性）
+
+**Response (200)**:
+```json
+{
+  "reactions": [
+    {"type": "like", "count": 15},
+    {"type": "love", "count": 8},
+    {"type": "haha", "count": 3}
+  ],
+  "user_reaction": {
+    "ID": 1,
+    "type": "like"
+  }
+}
+```
+
+**說明**: `user_reaction` 僅在登入時返回，顯示當前使用者的反應
+
+---
+
+### 4. 取得留言的反應統計
+**GET** `/comments/:comment_id/reactions`
+
+**需要登入**: ❌（選擇性）
+
+**Response**: 與文章反應統計相同
+
+---
+
+## 🔒 權限說明
+
+### 文章權限
+- **public**: 所有人可見
+- **private**: 僅作者可見
+- **friends**: 僅好友可見（需實作好友系統）
+
+### 操作權限
+- 建立：需登入
+- 閱讀：依文章可見性
+- 更新：僅作者
+- 刪除：作者或管理員
+
+---
+
+## 📊 資料庫關係
+
+```
+User (使用者)
+  ├─ has many Posts (文章)
+  ├─ has many Comments (留言)
+  └─ has many Reactions (反應)
+
+Post (文章)
+  ├─ belongs to User (作者)
+  ├─ has many Tags (標籤) - 多對多
+  ├─ has many Comments (留言)
+  └─ has many Reactions (反應)
+
+Comment (留言)
+  ├─ belongs to Post (文章)
+  ├─ belongs to User (作者)
+  ├─ has many Replies (回覆) - 自關聯
+  └─ has many Reactions (反應)
+
+Reaction (反應)
+  ├─ belongs to User
+  └─ belongs to Post OR Comment (擇一)
+
+Tag (標籤)
+  └─ has many Posts - 多對多
+```
+
+---
+
+## 🚀 使用範例
+
+### 完整發文流程
+```bash
+# 1. 登入
+curl -X POST http://localhost/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"password123"}' \
+  -c cookies.txt
+
+# 2. 建立文章
+curl -X POST http://localhost/api/posts \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "title":"Go 語言入門",
+    "content":"這是一篇關於 Go 的教學...",
+    "status":"published",
+    "tags":["Go","教學"]
+  }'
+
+# 3. 對文章按讚
+curl -X POST http://localhost/api/posts/1/reactions \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{"type":"like"}'
+
+# 4. 留言
+curl -X POST http://localhost/api/posts/1/comments \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{"content":"寫得很棒！"}'
+```
+
+---
+
+## ⚠️ 錯誤處理
+
+所有 API 在發生錯誤時會返回適當的 HTTP 狀態碼和錯誤訊息：
+
+```json
+{
+  "error": "錯誤描述"
+}
+```
+
+常見狀態碼：
+- `400` - 請求格式錯誤
+- `401` - 未授權（需要登入）
+- `403` - 禁止訪問（權限不足）
+- `404` - 資源不存在
+- `500` - 伺服器錯誤

--- a/POST_SYSTEM_README.md
+++ b/POST_SYSTEM_README.md
@@ -1,0 +1,71 @@
+# 發文、留言、心情系統 - 快速導覽
+
+## 📚 文檔索引
+
+### 🎯 API 文檔
+- **[POST_SYSTEM_API.md](./POST_SYSTEM_API.md)** - 新增的發文、留言、心情系統 API 完整文檔
+  - 文章 CRUD API
+  - 留言系統 API
+  - 反應/心情 API
+  
+- **[api_document.md](./api_document.md)** - 原有的認證、儲存等 API 文檔
+
+### 🔧 實作指南
+- **[IMPLEMENTATION_GUIDE.md](./IMPLEMENTATION_GUIDE.md)** - 後端實作完整指南
+  - 功能總覽
+  - 進階功能建議
+  - 測試步驟
+
+### 🎨 前端整合
+- **[VUE_FRONTEND_GUIDE.md](./VUE_FRONTEND_GUIDE.md)** - Vue 3 前端整合完整教學
+  - API 服務層
+  - Composables
+  - Vue 元件
+  - 完整範例程式碼
+
+- **[FRONTEND_BACKEND_CONNECTION.md](./FRONTEND_BACKEND_CONNECTION.md)** - 前後端連接配置
+  - Docker 容器間通訊
+  - Vite 代理設定
+  - CORS 配置
+  - 故障排除
+
+---
+
+## 🚀 快速開始
+
+### 後端已完成
+✅ 所有功能已實作並運行在容器內
+
+### 前端設定（3 步驟）
+
+1. **在前端容器測試連接**
+   ```bash
+   curl http://backend/api/posts
+   ```
+
+2. **配置 Vite 代理**（參考 FRONTEND_BACKEND_CONNECTION.md）
+   
+3. **建立 Vue 元件**（參考 VUE_FRONTEND_GUIDE.md）
+
+---
+
+## 📋 功能清單
+
+- ✅ 文章系統（建立、編輯、刪除、瀏覽）
+- ✅ 留言系統（留言、回覆、編輯、刪除）
+- ✅ 心情反應系統（7 種表情符號）
+- ✅ 標籤系統
+- ✅ 權限控制
+- ✅ 分頁功能
+
+---
+
+## 🛠️ 技術棧
+
+**後端**: Go + Gin + GORM + MySQL
+**前端**: Vue 3 + Vite
+**部署**: Docker
+
+---
+
+需要協助請參考對應的文檔！

--- a/controllers/post/comment.go
+++ b/controllers/post/comment.go
@@ -1,0 +1,202 @@
+package post
+
+import (
+	"net/http"
+	"personal_site/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// CreateCommentRequest 建立留言請求
+type CreateCommentRequest struct {
+	Content  string `json:"content" binding:"required,min=1"`
+	ParentID *uint  `json:"parent_id"` // 如果是回覆，提供父留言 ID
+}
+
+// UpdateCommentRequest 更新留言請求
+type UpdateCommentRequest struct {
+	Content string `json:"content" binding:"required,min=1"`
+}
+
+// CreateComment 建立留言
+func CreateComment(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+	var req CreateCommentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	// 檢查文章是否存在
+	var post models.Post
+	if err := db.First(&post, postID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Post not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch post"})
+		return
+	}
+
+	// 如果是回覆，檢查父留言是否存在
+	if req.ParentID != nil {
+		var parentComment models.Comment
+		if err := db.First(&parentComment, *req.ParentID).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Parent comment not found"})
+			return
+		}
+		// 確保父留言屬於同一篇文章
+		if parentComment.PostID != post.ID {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Parent comment does not belong to this post"})
+			return
+		}
+	}
+
+	// 建立留言
+	comment := models.Comment{
+		PostID:   post.ID,
+		AuthorID: userID.(uint),
+		Content:  req.Content,
+		ParentID: req.ParentID,
+	}
+
+	if err := db.Create(&comment).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create comment"})
+		return
+	}
+
+	// 載入作者資料
+	db.Preload("Author").First(&comment, comment.ID)
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "Comment created successfully",
+		"comment": comment,
+	})
+}
+
+// GetComments 取得文章的所有留言
+func GetComments(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+
+	// 檢查文章是否存在
+	var post models.Post
+	if err := db.First(&post, postID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Post not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch post"})
+		return
+	}
+
+	var comments []models.Comment
+	// 只取得頂層留言（沒有父留言的）
+	if err := db.Where("post_id = ? AND parent_id IS NULL AND is_deleted = ?", postID, false).
+		Preload("Author").
+		Preload("Reactions").
+		Preload("Replies", "is_deleted = ?", false).
+		Preload("Replies.Author").
+		Preload("Replies.Reactions").
+		Order("created_at DESC").
+		Find(&comments).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch comments"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"comments": comments})
+}
+
+// UpdateComment 更新留言
+func UpdateComment(c *gin.Context, db *gorm.DB) {
+	commentID := c.Param("comment_id")
+	var req UpdateCommentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	var comment models.Comment
+	if err := db.First(&comment, commentID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Comment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch comment"})
+		return
+	}
+
+	// 檢查是否為作者
+	if comment.AuthorID != userID.(uint) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "You can only edit your own comments"})
+		return
+	}
+
+	// 更新留言
+	if err := db.Model(&comment).Updates(map[string]interface{}{
+		"content":   req.Content,
+		"is_edited": true,
+	}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update comment"})
+		return
+	}
+
+	// 重新載入資料
+	db.Preload("Author").First(&comment, comment.ID)
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Comment updated successfully",
+		"comment": comment,
+	})
+}
+
+// DeleteComment 刪除留言（軟刪除）
+func DeleteComment(c *gin.Context, db *gorm.DB) {
+	commentID := c.Param("comment_id")
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	var comment models.Comment
+	if err := db.First(&comment, commentID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Comment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch comment"})
+		return
+	}
+
+	// 檢查權限
+	role, _ := c.Get("role")
+	if comment.AuthorID != userID.(uint) && role != string(models.RoleAdmin) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "You can only delete your own comments"})
+		return
+	}
+
+	// 軟刪除（標記為已刪除，保留結構）
+	if err := db.Model(&comment).Updates(map[string]interface{}{
+		"is_deleted": true,
+		"content":    "[此留言已刪除]",
+	}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete comment"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Comment deleted successfully"})
+}

--- a/controllers/post/post.go
+++ b/controllers/post/post.go
@@ -1,0 +1,354 @@
+package post
+
+import (
+	"net/http"
+	"personal_site/models"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// CreatePostRequest 建立文章請求
+type CreatePostRequest struct {
+	Title      string                 `json:"title" binding:"required,min=1,max=255"`
+	Content    string                 `json:"content" binding:"required"`
+	Summary    string                 `json:"summary" binding:"max=500"`
+	CoverImage string                 `json:"cover_image" binding:"omitempty,url"`
+	Status     models.PostStatus      `json:"status" binding:"omitempty,oneof=draft published archived"`
+	Visibility models.PostVisibility  `json:"visibility" binding:"omitempty,oneof=public private friends"`
+	Tags       []string               `json:"tags"`
+}
+
+// UpdatePostRequest 更新文章請求
+type UpdatePostRequest struct {
+	Title      *string                `json:"title" binding:"omitempty,min=1,max=255"`
+	Content    *string                `json:"content" binding:"omitempty"`
+	Summary    *string                `json:"summary" binding:"omitempty,max=500"`
+	CoverImage *string                `json:"cover_image" binding:"omitempty,url"`
+	Status     *models.PostStatus     `json:"status" binding:"omitempty,oneof=draft published archived"`
+	Visibility *models.PostVisibility `json:"visibility" binding:"omitempty,oneof=public private friends"`
+	Tags       []string               `json:"tags"`
+}
+
+// CreatePost 建立文章
+func CreatePost(c *gin.Context, db *gorm.DB) {
+	var req CreatePostRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 取得當前使用者 ID
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	// 設定預設值
+	if req.Status == "" {
+		req.Status = models.PostStatusDraft
+	}
+	if req.Visibility == "" {
+		req.Visibility = models.PostVisibilityPublic
+	}
+
+	// 建立文章
+	post := models.Post{
+		AuthorID:   userID.(uint),
+		Title:      req.Title,
+		Content:    req.Content,
+		Summary:    req.Summary,
+		CoverImage: req.CoverImage,
+		Status:     req.Status,
+		Visibility: req.Visibility,
+	}
+
+	// 開始事務
+	tx := db.Begin()
+
+	if err := tx.Create(&post).Error; err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create post"})
+		return
+	}
+
+	// 處理標籤
+	if len(req.Tags) > 0 {
+		var tags []models.Tag
+		for _, tagName := range req.Tags {
+			var tag models.Tag
+			// 嘗試找到現有標籤，如果不存在則建立
+			if err := tx.Where("name = ?", tagName).FirstOrCreate(&tag, models.Tag{
+				Name: tagName,
+				Slug: tagName, // 可以使用套件轉換為 slug
+			}).Error; err != nil {
+				tx.Rollback()
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process tags"})
+				return
+			}
+			tags = append(tags, tag)
+		}
+		// 關聯標籤
+		if err := tx.Model(&post).Association("Tags").Append(tags); err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to associate tags"})
+			return
+		}
+	}
+
+	tx.Commit()
+
+	// 載入作者和標籤資料
+	db.Preload("Author").Preload("Tags").First(&post, post.ID)
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "Post created successfully",
+		"post":    post,
+	})
+}
+
+// GetPosts 取得文章列表（分頁、篩選）
+func GetPosts(c *gin.Context, db *gorm.DB) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	status := c.Query("status")
+	tag := c.Query("tag")
+
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 10
+	}
+
+	offset := (page - 1) * pageSize
+
+	query := db.Model(&models.Post{}).
+		Preload("Author").
+		Preload("Tags").
+		Preload("Reactions")
+
+	// 篩選已發布的公開文章（如果未登入）
+	userID, exists := c.Get("user_id")
+	if !exists {
+		query = query.Where("status = ? AND visibility = ?", models.PostStatusPublished, models.PostVisibilityPublic)
+	} else {
+		// 如果已登入，可以看到自己的所有文章和其他人的公開文章
+		query = query.Where("(author_id = ? OR (status = ? AND visibility = ?))",
+			userID.(uint), models.PostStatusPublished, models.PostVisibilityPublic)
+	}
+
+	// 狀態篩選
+	if status != "" {
+		query = query.Where("status = ?", status)
+	}
+
+	// 標籤篩選
+	if tag != "" {
+		query = query.Joins("JOIN post_tags ON post_tags.post_id = posts.id").
+			Joins("JOIN tags ON tags.id = post_tags.tag_id").
+			Where("tags.name = ?", tag)
+	}
+
+	// 取得總數
+	var total int64
+	query.Count(&total)
+
+	// 取得文章列表
+	var posts []models.Post
+	if err := query.Order("created_at DESC").
+		Offset(offset).
+		Limit(pageSize).
+		Find(&posts).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch posts"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"posts": posts,
+		"pagination": gin.H{
+			"page":       page,
+			"page_size":  pageSize,
+			"total":      total,
+			"total_pages": (total + int64(pageSize) - 1) / int64(pageSize),
+		},
+	})
+}
+
+// GetPost 取得單一文章
+func GetPost(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+
+	var post models.Post
+	query := db.Preload("Author").
+		Preload("Tags").
+		Preload("Comments", "is_deleted = ?", false).
+		Preload("Comments.Author").
+		Preload("Comments.Reactions").
+		Preload("Reactions").
+		Preload("Reactions.User")
+
+	if err := query.First(&post, postID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Post not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch post"})
+		return
+	}
+
+	// 檢查權限
+	userID, exists := c.Get("user_id")
+	if post.Visibility == models.PostVisibilityPrivate {
+		if !exists || userID.(uint) != post.AuthorID {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+			return
+		}
+	}
+
+	// 增加瀏覽次數
+	db.Model(&post).Update("view_count", gorm.Expr("view_count + 1"))
+	post.ViewCount++
+
+	c.JSON(http.StatusOK, gin.H{"post": post})
+}
+
+// UpdatePost 更新文章
+func UpdatePost(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+	var req UpdatePostRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	var post models.Post
+	if err := db.First(&post, postID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Post not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch post"})
+		return
+	}
+
+	// 檢查是否為作者
+	if post.AuthorID != userID.(uint) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "You can only edit your own posts"})
+		return
+	}
+
+	// 更新欄位
+	tx := db.Begin()
+
+	updates := make(map[string]interface{})
+	if req.Title != nil {
+		updates["title"] = *req.Title
+	}
+	if req.Content != nil {
+		updates["content"] = *req.Content
+	}
+	if req.Summary != nil {
+		updates["summary"] = *req.Summary
+	}
+	if req.CoverImage != nil {
+		updates["cover_image"] = *req.CoverImage
+	}
+	if req.Status != nil {
+		updates["status"] = *req.Status
+		// 如果變更為已發布且 PublishedAt 為空
+		if *req.Status == models.PostStatusPublished && post.PublishedAt == nil {
+			now := time.Now()
+			updates["published_at"] = now
+		}
+	}
+	if req.Visibility != nil {
+		updates["visibility"] = *req.Visibility
+	}
+
+	if len(updates) > 0 {
+		if err := tx.Model(&post).Updates(updates).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update post"})
+			return
+		}
+	}
+
+	// 更新標籤
+	if req.Tags != nil {
+		var tags []models.Tag
+		for _, tagName := range req.Tags {
+			var tag models.Tag
+			if err := tx.Where("name = ?", tagName).FirstOrCreate(&tag, models.Tag{
+				Name: tagName,
+				Slug: tagName,
+			}).Error; err != nil {
+				tx.Rollback()
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process tags"})
+				return
+			}
+			tags = append(tags, tag)
+		}
+		// 替換標籤
+		if err := tx.Model(&post).Association("Tags").Replace(tags); err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update tags"})
+			return
+		}
+	}
+
+	tx.Commit()
+
+	// 重新載入資料
+	db.Preload("Author").Preload("Tags").First(&post, post.ID)
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Post updated successfully",
+		"post":    post,
+	})
+}
+
+// DeletePost 刪除文章
+func DeletePost(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	var post models.Post
+	if err := db.First(&post, postID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Post not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch post"})
+		return
+	}
+
+	// 檢查權限（只有作者或管理員可以刪除）
+	role, _ := c.Get("role")
+	if post.AuthorID != userID.(uint) && role != string(models.RoleAdmin) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "You can only delete your own posts"})
+		return
+	}
+
+	// 刪除文章（會級聯刪除留言和反應）
+	if err := db.Delete(&post).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete post"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Post deleted successfully"})
+}

--- a/controllers/post/reaction.go
+++ b/controllers/post/reaction.go
@@ -1,0 +1,224 @@
+package post
+
+import (
+	"net/http"
+	"personal_site/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// AddReactionRequest 新增反應請求
+type AddReactionRequest struct {
+	Type models.ReactionType `json:"type" binding:"required,oneof=like love haha wow sad angry care"`
+}
+
+// AddReactionToPost 對文章新增反應
+func AddReactionToPost(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+	var req AddReactionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	// 檢查文章是否存在
+	var post models.Post
+	if err := db.First(&post, postID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Post not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch post"})
+		return
+	}
+
+	// 檢查是否已經有反應
+	var existingReaction models.Reaction
+	err := db.Where("user_id = ? AND post_id = ?", userID.(uint), post.ID).First(&existingReaction).Error
+
+	if err == nil {
+		// 已有反應，更新類型
+		if existingReaction.Type == req.Type {
+			// 相同類型，刪除反應（取消）
+			if err := db.Delete(&existingReaction).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove reaction"})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"message": "Reaction removed"})
+			return
+		}
+		// 不同類型，更新
+		if err := db.Model(&existingReaction).Update("type", req.Type).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update reaction"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"message":  "Reaction updated",
+			"reaction": existingReaction,
+		})
+		return
+	}
+
+	// 沒有反應，建立新的
+	reaction := models.Reaction{
+		UserID: userID.(uint),
+		PostID: &post.ID,
+		Type:   req.Type,
+	}
+
+	if err := db.Create(&reaction).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add reaction"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message":  "Reaction added",
+		"reaction": reaction,
+	})
+}
+
+// AddReactionToComment 對留言新增反應
+func AddReactionToComment(c *gin.Context, db *gorm.DB) {
+	commentID := c.Param("comment_id")
+	var req AddReactionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	// 檢查留言是否存在
+	var comment models.Comment
+	if err := db.First(&comment, commentID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Comment not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch comment"})
+		return
+	}
+
+	// 檢查是否已經有反應
+	var existingReaction models.Reaction
+	err := db.Where("user_id = ? AND comment_id = ?", userID.(uint), comment.ID).First(&existingReaction).Error
+
+	if err == nil {
+		// 已有反應
+		if existingReaction.Type == req.Type {
+			// 相同類型，刪除（取消）
+			if err := db.Delete(&existingReaction).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove reaction"})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"message": "Reaction removed"})
+			return
+		}
+		// 不同類型，更新
+		if err := db.Model(&existingReaction).Update("type", req.Type).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update reaction"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"message":  "Reaction updated",
+			"reaction": existingReaction,
+		})
+		return
+	}
+
+	// 沒有反應，建立新的
+	reaction := models.Reaction{
+		UserID:    userID.(uint),
+		CommentID: &comment.ID,
+		Type:      req.Type,
+	}
+
+	if err := db.Create(&reaction).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add reaction"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message":  "Reaction added",
+		"reaction": reaction,
+	})
+}
+
+// GetPostReactionsSummary 取得文章的反應統計
+func GetPostReactionsSummary(c *gin.Context, db *gorm.DB) {
+	postID := c.Param("id")
+
+	type ReactionCount struct {
+		Type  models.ReactionType `json:"type"`
+		Count int64               `json:"count"`
+	}
+
+	var reactions []ReactionCount
+	if err := db.Model(&models.Reaction{}).
+		Select("type, COUNT(*) as count").
+		Where("post_id = ?", postID).
+		Group("type").
+		Find(&reactions).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch reactions"})
+		return
+	}
+
+	// 取得當前使用者的反應
+	var userReaction *models.Reaction
+	if userID, exists := c.Get("user_id"); exists {
+		var reaction models.Reaction
+		if err := db.Where("user_id = ? AND post_id = ?", userID.(uint), postID).First(&reaction).Error; err == nil {
+			userReaction = &reaction
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"reactions":     reactions,
+		"user_reaction": userReaction,
+	})
+}
+
+// GetCommentReactionsSummary 取得留言的反應統計
+func GetCommentReactionsSummary(c *gin.Context, db *gorm.DB) {
+	commentID := c.Param("comment_id")
+
+	type ReactionCount struct {
+		Type  models.ReactionType `json:"type"`
+		Count int64               `json:"count"`
+	}
+
+	var reactions []ReactionCount
+	if err := db.Model(&models.Reaction{}).
+		Select("type, COUNT(*) as count").
+		Where("comment_id = ?", commentID).
+		Group("type").
+		Find(&reactions).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch reactions"})
+		return
+	}
+
+	// 取得當前使用者的反應
+	var userReaction *models.Reaction
+	if userID, exists := c.Get("user_id"); exists {
+		var reaction models.Reaction
+		if err := db.Where("user_id = ? AND comment_id = ?", userID.(uint), commentID).First(&reaction).Error; err == nil {
+			userReaction = &reaction
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"reactions":     reactions,
+		"user_reaction": userReaction,
+	})
+}

--- a/database/database.go
+++ b/database/database.go
@@ -20,7 +20,15 @@ func initMySQLDB(dsn string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("failed to connect to MySQL database: %v", err)
 	}
 
-	if err := db.AutoMigrate(&models.User{}, &models.YTDataAPITokenHistory{}, &models.BattleCatLevel{}); err != nil {
+	if err := db.AutoMigrate(
+		&models.User{},
+		&models.YTDataAPITokenHistory{},
+		&models.BattleCatLevel{},
+		&models.Post{},
+		&models.Tag{},
+		&models.Comment{},
+		&models.Reaction{},
+	); err != nil {
 		return nil, fmt.Errorf("auto migrate failed: %v", err)
 	}
 
@@ -33,7 +41,15 @@ func initSQLiteDB(dsn string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("failed to connect to SQLite database: %v", err)
 	}
 
-	if err := db.AutoMigrate(&models.User{}, &models.YTDataAPITokenHistory{}, &models.BattleCatLevel{}); err != nil {
+	if err := db.AutoMigrate(
+		&models.User{},
+		&models.YTDataAPITokenHistory{},
+		&models.BattleCatLevel{},
+		&models.Post{},
+		&models.Tag{},
+		&models.Comment{},
+		&models.Reaction{},
+	); err != nil {
 		return nil, fmt.Errorf("auto migrate failed: %v", err)
 	}
 

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -34,6 +34,8 @@ func AuthRequired() gin.HandlerFunc {
 		user := (&claims.Payload).ExtractUser()
 
 		c.Set("user", user)
+		c.Set("user_id", user.ID)
+		c.Set("role", user.Role)
 
 		c.Next()
 	}
@@ -74,6 +76,8 @@ func AuthOptional() gin.HandlerFunc {
 
 		user := (&claims.Payload).ExtractUser()
 		c.Set("user", user)
+		c.Set("user_id", user.ID)
+		c.Set("role", user.Role)
 
 		c.Next()
 	}

--- a/models/comment.go
+++ b/models/comment.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"gorm.io/gorm"
+)
+
+// Comment 留言模型
+type Comment struct {
+	gorm.Model
+	PostID      uint       `gorm:"not null;index"`                             // 文章 ID
+	Post        Post       `gorm:"foreignKey:PostID"`                          // 文章關聯
+	AuthorID    uint       `gorm:"not null;index"`                             // 作者 ID
+	Author      User       `gorm:"foreignKey:AuthorID"`                        // 作者關聯
+	Content     string     `gorm:"type:text;not null"`                         // 留言內容
+	ParentID    *uint      `gorm:"index"`                                      // 父留言 ID（用於回覆）
+	Parent      *Comment   `gorm:"foreignKey:ParentID"`                        // 父留言關聯
+	Replies     []Comment  `gorm:"foreignKey:ParentID;constraint:OnDelete:CASCADE"` // 子留言
+	Reactions   []Reaction `gorm:"foreignKey:CommentID;constraint:OnDelete:CASCADE"` // 反應
+	IsEdited    bool       `gorm:"default:false"`                              // 是否已編輯
+	IsDeleted   bool       `gorm:"default:false;index"`                        // 軟刪除標記
+}
+
+// TableName 指定表名
+func (Comment) TableName() string {
+	return "comments"
+}

--- a/models/post.go
+++ b/models/post.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// PostStatus 定義文章狀態
+type PostStatus string
+
+const (
+	PostStatusDraft     PostStatus = "draft"     // 草稿
+	PostStatusPublished PostStatus = "published" // 已發布
+	PostStatusArchived  PostStatus = "archived"  // 封存
+)
+
+// PostVisibility 定義文章可見性
+type PostVisibility string
+
+const (
+	PostVisibilityPublic  PostVisibility = "public"  // 公開
+	PostVisibilityPrivate PostVisibility = "private" // 私人
+	PostVisibilityFriends PostVisibility = "friends" // 僅好友
+)
+
+// Post 文章模型
+type Post struct {
+	gorm.Model
+	AuthorID   uint           `gorm:"not null;index"`                        // 作者 ID
+	Author     User           `gorm:"foreignKey:AuthorID"`                   // 作者關聯
+	Title      string         `gorm:"size:255;not null"`                     // 標題
+	Content    string         `gorm:"type:text;not null"`                    // 內容
+	Summary    string         `gorm:"size:500"`                              // 摘要
+	CoverImage string         `gorm:"size:500"`                              // 封面圖
+	Status     PostStatus     `gorm:"size:20;not null;default:'draft'"`      // 狀態
+	Visibility PostVisibility `gorm:"size:20;not null;default:'public'"`     // 可見性
+	ViewCount  int            `gorm:"default:0"`                             // 瀏覽次數
+	PublishedAt *time.Time    `gorm:"index"`                                 // 發布時間
+	Tags       []Tag          `gorm:"many2many:post_tags;"`                  // 標籤（多對多）
+	Comments   []Comment      `gorm:"foreignKey:PostID;constraint:OnDelete:CASCADE"` // 留言
+	Reactions  []Reaction     `gorm:"foreignKey:PostID;constraint:OnDelete:CASCADE"` // 反應
+}
+
+// Tag 標籤模型
+type Tag struct {
+	gorm.Model
+	Name  string `gorm:"size:50;not null;uniqueIndex"` // 標籤名稱
+	Slug  string `gorm:"size:50;not null;uniqueIndex"` // URL 友善名稱
+	Color string `gorm:"size:7;default:'#3B82F6'"`     // 標籤顏色
+	Posts []Post `gorm:"many2many:post_tags;"`         // 文章（多對多）
+}
+
+// BeforeSave 驗證資料
+func (p *Post) BeforeSave(tx *gorm.DB) error {
+	// 如果狀態變更為已發布且 PublishedAt 為空，設定發布時間
+	if p.Status == PostStatusPublished && p.PublishedAt == nil {
+		now := time.Now()
+		p.PublishedAt = &now
+	}
+	return nil
+}

--- a/models/reaction.go
+++ b/models/reaction.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"gorm.io/gorm"
+)
+
+// ReactionType 反應類型
+type ReactionType string
+
+const (
+	ReactionTypeLike    ReactionType = "like"    // 讚
+	ReactionTypeLove    ReactionType = "love"    // 愛心
+	ReactionTypeHaha    ReactionType = "haha"    // 哈哈
+	ReactionTypeWow     ReactionType = "wow"     // 驚訝
+	ReactionTypeSad     ReactionType = "sad"     // 難過
+	ReactionTypeAngry   ReactionType = "angry"   // 生氣
+	ReactionTypeCare    ReactionType = "care"    // 關心
+)
+
+// Reaction 反應模型（用於文章和留言）
+type Reaction struct {
+	gorm.Model
+	UserID    uint         `gorm:"not null;index:idx_reaction_unique,unique"` // 使用者 ID
+	User      User         `gorm:"foreignKey:UserID"`                         // 使用者關聯
+	PostID    *uint        `gorm:"index:idx_reaction_unique,unique"`          // 文章 ID（可為空）
+	Post      *Post        `gorm:"foreignKey:PostID"`                         // 文章關聯
+	CommentID *uint        `gorm:"index:idx_reaction_unique,unique"`          // 留言 ID（可為空）
+	Comment   *Comment     `gorm:"foreignKey:CommentID"`                      // 留言關聯
+	Type      ReactionType `gorm:"size:20;not null"`                          // 反應類型
+}
+
+// TableName 指定表名
+func (Reaction) TableName() string {
+	return "reactions"
+}
+
+// BeforeSave 驗證反應必須綁定到文章或留言
+func (r *Reaction) BeforeSave(tx *gorm.DB) error {
+	// 確保反應只能對文章或留言其中一個
+	if (r.PostID == nil && r.CommentID == nil) || (r.PostID != nil && r.CommentID != nil) {
+		return gorm.ErrInvalidData
+	}
+	return nil
+}

--- a/routers/post.go
+++ b/routers/post.go
@@ -1,0 +1,70 @@
+package routers
+
+import (
+	"personal_site/controllers/post"
+	"personal_site/middlewares"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type postRouter struct{}
+
+func (postRouter) RegisterRoutes(r *gin.RouterGroup, db *gorm.DB) {
+	// 文章相關路由
+	posts := r.Group("/posts")
+	{
+		// 公開路由
+		posts.GET("", middlewares.AuthOptional(), func(c *gin.Context) {
+			post.GetPosts(c, db)
+		})
+		posts.GET("/:id", middlewares.AuthOptional(), func(c *gin.Context) {
+			post.GetPost(c, db)
+		})
+		posts.GET("/:id/reactions", middlewares.AuthOptional(), func(c *gin.Context) {
+			post.GetPostReactionsSummary(c, db)
+		})
+
+		// 需要登入的路由
+		posts.POST("", middlewares.AuthRequired(), func(c *gin.Context) {
+			post.CreatePost(c, db)
+		})
+		posts.PUT("/:id", middlewares.AuthRequired(), func(c *gin.Context) {
+			post.UpdatePost(c, db)
+		})
+		posts.DELETE("/:id", middlewares.AuthRequired(), func(c *gin.Context) {
+			post.DeletePost(c, db)
+		})
+
+		// 反應相關
+		posts.POST("/:id/reactions", middlewares.AuthRequired(), func(c *gin.Context) {
+			post.AddReactionToPost(c, db)
+		})
+
+		// 留言相關路由
+		posts.GET("/:id/comments", middlewares.AuthOptional(), func(c *gin.Context) {
+			post.GetComments(c, db)
+		})
+		posts.POST("/:id/comments", middlewares.AuthRequired(), func(c *gin.Context) {
+			post.CreateComment(c, db)
+		})
+	}
+
+	// 留言相關路由
+	comments := r.Group("/comments")
+	comments.Use(middlewares.AuthRequired())
+	{
+		comments.PUT("/:comment_id", func(c *gin.Context) {
+			post.UpdateComment(c, db)
+		})
+		comments.DELETE("/:comment_id", func(c *gin.Context) {
+			post.DeleteComment(c, db)
+		})
+		comments.POST("/:comment_id/reactions", func(c *gin.Context) {
+			post.AddReactionToComment(c, db)
+		})
+		comments.GET("/:comment_id/reactions", middlewares.AuthOptional(), func(c *gin.Context) {
+			post.GetCommentReactionsSummary(c, db)
+		})
+	}
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -26,6 +26,9 @@ func RegisterRouters(r *gin.Engine, db *gorm.DB) {
 	var battleCatRouterVal Router = battleCatRouter{}
 	battleCatRouterVal.RegisterRoutes(mainRouter.Group("/battle-cat"), db)
 
+	var postRouterVal Router = postRouter{}
+	postRouterVal.RegisterRoutes(mainRouter, db)
+
 	mainRouter.GET("/get-yt-data-api-token", middlewares.AuthOptional(), func(c *gin.Context) {
 		controllers.GetYTDataAPIToken(c, db)
 	})

--- a/tests/api/post_test.go
+++ b/tests/api/post_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"personal_site/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatePost(t *testing.T) {
+	router, db := setupTestRouter()
+	defer cleanupTestDB(db)
+
+	// 建立測試使用者並登入
+	user, token := createTestUserAndLogin(t, db)
+
+	// 測試建立文章
+	postData := map[string]interface{}{
+		"title":      "測試文章",
+		"content":    "這是測試內容",
+		"summary":    "測試摘要",
+		"status":     "published",
+		"visibility": "public",
+		"tags":       []string{"測試", "Go"},
+	}
+
+	body, _ := json.Marshal(postData)
+	req, _ := http.NewRequest("POST", "/api/posts", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "auth_token", Value: token})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	assert.Equal(t, "Post created successfully", response["message"])
+	assert.NotNil(t, response["post"])
+
+	post := response["post"].(map[string]interface{})
+	assert.Equal(t, "測試文章", post["title"])
+	assert.Equal(t, float64(user.ID), post["author_id"])
+}
+
+func TestGetPosts(t *testing.T) {
+	router, db := setupTestRouter()
+	defer cleanupTestDB(db)
+
+	// 建立測試使用者和文章
+	user, _ := createTestUserAndLogin(t, db)
+	createTestPost(t, db, user.ID)
+
+	// 測試取得文章列表
+	req, _ := http.NewRequest("GET", "/api/posts", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	posts := response["posts"].([]interface{})
+	assert.Greater(t, len(posts), 0)
+}
+
+func TestGetPost(t *testing.T) {
+	router, db := setupTestRouter()
+	defer cleanupTestDB(db)
+
+	user, _ := createTestUserAndLogin(t, db)
+	post := createTestPost(t, db, user.ID)
+
+	// 測試取得單一文章
+	req, _ := http.NewRequest("GET", "/api/posts/"+string(rune(post.ID)), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	postData := response["post"].(map[string]interface{})
+	assert.Equal(t, "測試文章", postData["title"])
+}
+
+func TestUpdatePost(t *testing.T) {
+	router, db := setupTestRouter()
+	defer cleanupTestDB(db)
+
+	user, token := createTestUserAndLogin(t, db)
+	post := createTestPost(t, db, user.ID)
+
+	// 測試更新文章
+	updateData := map[string]interface{}{
+		"title":   "更新後的標題",
+		"content": "更新後的內容",
+	}
+
+	body, _ := json.Marshal(updateData)
+	req, _ := http.NewRequest("PUT", "/api/posts/"+string(rune(post.ID)), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "auth_token", Value: token})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	assert.Equal(t, "Post updated successfully", response["message"])
+}
+
+func TestDeletePost(t *testing.T) {
+	router, db := setupTestRouter()
+	defer cleanupTestDB(db)
+
+	user, token := createTestUserAndLogin(t, db)
+	post := createTestPost(t, db, user.ID)
+
+	// 測試刪除文章
+	req, _ := http.NewRequest("DELETE", "/api/posts/"+string(rune(post.ID)), nil)
+	req.AddCookie(&http.Cookie{Name: "auth_token", Value: token})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// 驗證文章已被刪除
+	var deletedPost models.Post
+	err := db.First(&deletedPost, post.ID).Error
+	assert.Error(t, err) // 應該找不到
+}
+
+// Helper functions
+func createTestPost(t *testing.T, db *gorm.DB, authorID uint) *models.Post {
+	post := &models.Post{
+		AuthorID:   authorID,
+		Title:      "測試文章",
+		Content:    "測試內容",
+		Status:     models.PostStatusPublished,
+		Visibility: models.PostVisibilityPublic,
+	}
+	err := db.Create(post).Error
+	assert.NoError(t, err)
+	return post
+}


### PR DESCRIPTION
- 新增 Post, Comment, Reaction 資料模型
- 實作完整的文章 CRUD 功能
- 實作巢狀留言系統（支援回覆）
- 實作多種心情反應（7種類型） cd /app/backend && go run main.go
- 更新資料庫自動遷移
- 增強認證中間件（支援 optional auth）
-  API 文檔和測試框架

cd /app/backend && go run main.go &
- 文章支援草稿/發布/封存狀態
- 文章可見性控制（公/私人/僅好友）
- 留言支援軟刪除和編輯標記
- 按讚統計（GROUP BY 聚合） cd /app/backend && go run main.go /刪除）